### PR TITLE
Extended Local Storage

### DIFF
--- a/metareserve_geni/cli/allocate.py
+++ b/metareserve_geni/cli/allocate.py
@@ -73,7 +73,7 @@ def build_profile_interactive(node_amount):
                 f.write(str(profile))
             print('Wrote config at location: {}'.format(fs.join(loc.profiledir(), cached_profilename)))
             break
-    prints('Resrvation profile creation success.')
+    prints('Reservation profile creation success.')
     return profile
 
 

--- a/metareserve_geni/cli/allocate.py
+++ b/metareserve_geni/cli/allocate.py
@@ -36,6 +36,7 @@ def build_profile_interactive(node_amount):
     cached_hwtype = None
     cached_image = 'urn:publicid:IDN+emulab.net+image+emulab-ops//UBUNTU20-64-STD'
     picked_names = []
+    cached_block_store_size = 0
     for idx in range(node_amount):
         print('Processing node {}/{}'.format(idx+1, node_amount))
         
@@ -51,8 +52,11 @@ def build_profile_interactive(node_amount):
         
         img_question = '\timage [{}]:'.format(cached_image)
         cached_image = _cached(ui.ask_string(img_question, empty_ok=True), cached_image)
+
+        block_store_size_question = '\tblockstore size (\'0\' for no extra storage) [{}]'.format(cached_block_store_size)
+        cached_block_store_size = _cached(ui.ask_string(block_store_size_question, empty_ok=True), cached_block_store_size)
         
-        profile.add(GENINode(reply_name, cached_hwtype, cached_image))
+        profile.add(GENINode(reply_name, cached_hwtype, cached_image, block_store_size=cached_block_store_size))
 
     print('Reservation profile complete.')
     if ui.ask_bool('Save profile? [N]:', empty_ok=True):

--- a/metareserve_geni/cli/allocate.py
+++ b/metareserve_geni/cli/allocate.py
@@ -55,7 +55,7 @@ def build_profile_interactive(node_amount):
 
         block_store_size_question = '\tblockstore size (\'0\' for no extra storage) [{}]'.format(cached_block_store_size)
         cached_block_store_size = _cached(ui.ask_string(block_store_size_question, empty_ok=True), cached_block_store_size)
-        
+
         profile.add(GENINode(reply_name, cached_hwtype, cached_image, block_store_size=cached_block_store_size))
 
     print('Reservation profile complete.')

--- a/metareserve_geni/internal/gni/py2/allocate.py
+++ b/metareserve_geni/internal/gni/py2/allocate.py
@@ -23,7 +23,7 @@ def create_baremetal_node(name, img, hardware_type, block_store_size='0'):
     node.disk_image = img
     node.hardware_type = hardware_type
     if block_store_size != '0' and block_store_size != 0:
-        bs = node.Blockstore('bs', '/localblob')
+        bs = node.Blockstore('bs_{}'.format(name), '/localblob')
         bs.size = '{}GB'.format(block_store_size)
     return node
 

--- a/metareserve_geni/internal/gni/py2/allocate.py
+++ b/metareserve_geni/internal/gni/py2/allocate.py
@@ -18,11 +18,11 @@ from connectinfo import RawConnectInfo
 '''CLI module to start a cluster.'''
 
 
-def create_baremetal_node(name, img, hardware_type, block_store_size=0):
+def create_baremetal_node(name, img, hardware_type, block_store_size='0'):
     node = pg.RawPC(name)
     node.disk_image = img
     node.hardware_type = hardware_type
-    if block_store_size != 0:
+    if block_store_size != '0' and block_store_size != 0:
         bs = node.Blockstore('bs', '/localblob')
         bs.size = '{}GB'.format(block_store_size)
     return node

--- a/metareserve_geni/internal/gni/py2/allocate.py
+++ b/metareserve_geni/internal/gni/py2/allocate.py
@@ -4,6 +4,7 @@ import socket
 import sys
 
 from geni.rspec import pg
+from geni.rspec.igext import Blockstore
 import geni.aggregate.cloudlab
 
 import alloc.generic as generic
@@ -17,10 +18,13 @@ from connectinfo import RawConnectInfo
 '''CLI module to start a cluster.'''
 
 
-def create_baremetal_node(name, img, hardware_type):
+def create_baremetal_node(name, img, hardware_type, block_store_size=0):
     node = pg.RawPC(name)
     node.disk_image = img
     node.hardware_type = hardware_type
+    if block_store_size != 0:
+        bs = node.Blockstore('bs', '/localblob')
+        bs.size = '{}GB'.format(block_store_size)
     return node
 
 
@@ -46,7 +50,7 @@ def create_request(allocrequest):
     geni_nodes = []
 
     for node in allocrequest.list():
-        geni_node = create_baremetal_node(node.name, node.img, node.hw_type)
+        geni_node = create_baremetal_node(node.name, node.img, node.hw_type, block_store_size=node.block_store_size)
         geni_nodes.append(geni_node)
         request.addResource(geni_node)
 

--- a/metareserve_geni/internal/gni/py2bridge.py
+++ b/metareserve_geni/internal/gni/py2bridge.py
@@ -15,7 +15,7 @@ from internal.util.printer import *
 def _to_internal_request(reservation_request):
     allocrequest = _AllocRequest()
     for x in reservation_request.nodes:
-        allocrequest.add(x.name, x.hw_type, x.image)
+        allocrequest.add(x.name, x.hw_type, x.image, x.block_store_size)
     return allocrequest
 
 

--- a/metareserve_geni/internal/gni/shared/allocrequest.py
+++ b/metareserve_geni/internal/gni/shared/allocrequest.py
@@ -7,7 +7,7 @@ class AllocRequest(object):
         self.nodes = []
 
 
-    def add(self, name, hw_type='c6525-25g', img='urn:publicid:IDN+emulab.net+image+emulab-ops//UBUNTU20-64-STD'):
+    def add(self, name, hw_type='c6525-25g', img='urn:publicid:IDN+emulab.net+image+emulab-ops//UBUNTU20-64-STD', block_store_size='0'):
         '''Adds node to request. Note: The `name` of the node must be unique. Note: `name` may not contain '|'.
         Args:
             name: Used as node name. GENI will use this name as hostname for the spawned node.
@@ -18,7 +18,7 @@ class AllocRequest(object):
             raise ValueError('Node name "{}" includes illegal character "|"!'.format(name))
         if any(x.isupper() for x in name):
             print('[WARNING] Node name "{}" contains uppercase letters. Transformed to lowercase, because GENI does not understand stuff otherwise.'.format(name))
-        self.nodes.append(Node(name.lower(), hw_type, img))
+        self.nodes.append(Node(name.lower(), hw_type, img, block_store_size=block_store_size))
 
 
     def list(self):
@@ -53,9 +53,9 @@ class Node(object):
 
 
     def __str__(self):
-        return '|'.join(str(x) for x in (self.name, self.hw_type, self.img, self.block_store_size))
+        return '|'.join(str(x) for x in (self.name, self.hw_type, self.img))
 
 
     @staticmethod
     def from_string(string):
-        return Node(*string.split('|', 2))
+        return Node(*string.split('|', 3))

--- a/metareserve_geni/internal/gni/shared/allocrequest.py
+++ b/metareserve_geni/internal/gni/shared/allocrequest.py
@@ -53,7 +53,7 @@ class Node(object):
 
 
     def __str__(self):
-        return '|'.join(str(x) for x in (self.name, self.hw_type, self.img))
+        return '|'.join(str(x) for x in (self.name, self.hw_type, self.img, self.block_store_size))
 
 
     @staticmethod

--- a/metareserve_geni/internal/gni/shared/allocrequest.py
+++ b/metareserve_geni/internal/gni/shared/allocrequest.py
@@ -45,14 +45,15 @@ class AllocRequest(object):
 
 class Node(object):
     '''Object to store individual node requests.'''
-    def __init__(self, name, hw_type='c6525-25g', img='urn:publicid:IDN+emulab.net+image+emulab-ops//UBUNTU20-64-STD'):
+    def __init__(self, name, hw_type='c6525-25g', img='urn:publicid:IDN+emulab.net+image+emulab-ops//UBUNTU20-64-STD', block_store_size='0'):
         self.name = name
         self.hw_type = hw_type
         self.img = img
+        self.block_store_size = block_store_size
 
 
     def __str__(self):
-        return '|'.join(str(x) for x in (self.name, self.hw_type, self.img))
+        return '|'.join(str(x) for x in (self.name, self.hw_type, self.img, self.block_store_size))
 
 
     @staticmethod

--- a/metareserve_geni/reservation.py
+++ b/metareserve_geni/reservation.py
@@ -5,7 +5,7 @@ class GENINode(object):
     Args:
         name (str): Hostname for this node.
         hw_type (str): Hardware type. Check the available hardware types and their specifications at (e.g.) https://www.cloudlab.us/resinfo.php.
-        image (str): OS image to boot on node.
+        image (str): OS image to boot on node. 
         block_store_size (str) (optional): size in GB of extended storage'''
     def __init__(self, name, hw_type, image, block_store_size='0'):
         self._name = name
@@ -35,7 +35,7 @@ class GENINode(object):
         return GENINode(*string.split('|'))
 
     def __str__(self):
-        return '|'.join([self._name, self._hw_type, self._image])
+        return '|'.join([self._name, self._hw_type, self._image, self._block_store_size])
 
 
 

--- a/metareserve_geni/reservation.py
+++ b/metareserve_geni/reservation.py
@@ -35,7 +35,7 @@ class GENINode(object):
         return GENINode(*string.split('|'))
 
     def __str__(self):
-        return '|'.join([self._name, self._hw_type, self._image, self._block_store_size])
+        return '|'.join([self._name, self._hw_type, self._image])
 
 
 

--- a/metareserve_geni/reservation.py
+++ b/metareserve_geni/reservation.py
@@ -5,11 +5,13 @@ class GENINode(object):
     Args:
         name (str): Hostname for this node.
         hw_type (str): Hardware type. Check the available hardware types and their specifications at (e.g.) https://www.cloudlab.us/resinfo.php.
-        image (str): OS image to boot on node.'''
-    def __init__(self, name, hw_type, image):
+        image (str): OS image to boot on node.
+        block_store_size (str) (optional): size in GB of extended storage'''
+    def __init__(self, name, hw_type, image, block_store_size='0'):
         self._name = name
         self._hw_type = hw_type
         self._image = image
+        self._block_store_size = block_store_size
 
     @property
     def name(self):
@@ -22,6 +24,10 @@ class GENINode(object):
     @property
     def image(self):
         return self._image
+
+    @property
+    def block_store_size(self):
+        return self._block_store_size
 
     @staticmethod
     def from_string(string):

--- a/metareserve_geni/reservation.py
+++ b/metareserve_geni/reservation.py
@@ -35,7 +35,7 @@ class GENINode(object):
         return GENINode(*string.split('|'))
 
     def __str__(self):
-        return '|'.join([self._name, self._hw_type, self._image])
+        return '|'.join([self._name, self._hw_type, self._image, self._block_store_size])
 
 
 


### PR DESCRIPTION
Main contribution of this pull request: allocations can now also request extended storage through a local blockstore. 
If not extra storage is requested, the reservation is identical to current reservations. 

Additionally: fixed a typo in `metareserve_geni/cli/allocate` 